### PR TITLE
Feature/imports change

### DIFF
--- a/examples/Smakefile
+++ b/examples/Smakefile
@@ -1,5 +1,5 @@
 import click
-from smaker.runner import SnakeRunner
+from smaker import SnakeRunner
 
 hello = SnakeRunner(default_snakefile='hello_world/Snakefile.hello', default_config='hello_world/config.json')
 hello.add_endpoint('hello', params={})

--- a/examples/Snakefile
+++ b/examples/Snakefile
@@ -1,5 +1,5 @@
 import os
-from smaker.utils import scrape_error_logs, scrape_final_targets
+import smaker
 
 workdir: config['workdir']
 
@@ -7,11 +7,11 @@ for module_path in config['modules'].values():
     include: module_path
 
 rule all:
-    input: [ os.path.join(o,targ) for o in config['final_paths'] for targ in scrape_final_targets(rules) ]
+    input: [ os.path.join(o,targ) for o in config['final_paths'] for targ in smaker.scrape_final_targets(rules) ]
 
 onerror:
     start = '%s\nPrinting error log:' % ''.join(['=']*100)
     end = '\nEnd of error log\n%s' % ''.join(['=']*100)
-    for error_log in scrape_error_logs(log):
+    for error_log in smaker.scrape_error_logs(log):
         shell('echo "%s" && echo "%s\n" && cat %s && echo "%s"' % (start, error_log, error_log, end))
 

--- a/examples/hello_world/Snakefile.hello
+++ b/examples/hello_world/Snakefile.hello
@@ -17,8 +17,9 @@ run_wildcards=config.get('run_wildcards', '')
 rule hello:
     output:
         touch('%s/hello.success' % output_path)
+    threads: 3
     shell:
-        'echo "Hello World!"'
+        'echo "Hello World! {threads}"'
 
 # This "hello_or_goodbye" rule takes two parameters:
 #     - param-level "say_hello" flag

--- a/scripts/test_example_endpoints.sh
+++ b/scripts/test_example_endpoints.sh
@@ -16,6 +16,7 @@ smaker fly \
     -s simple/Snakefile \
     --source=$SOURCE \
     --output-path=$OUTPUT_PATH \
+    -F \
     -v |\
     grep "$OUTPUT_PATH/$SOURCE"
 
@@ -24,6 +25,7 @@ smaker fly \
     -s simple/Snakefile \
     --source $SOURCE \
     --output-path $OUTPUT_PATH \
+    -F \
     -v |\
     grep "$OUTPUT_PATH/default"
 
@@ -31,10 +33,11 @@ smaker fly \
     -c simple/config.json \
     -s Snakefile \
     --module hello_world/Snakefile.hello \
+    -F \
     --quiet
 
 for endpoint in $(smaker list); do
-    smaker run -e $endpoint --quiet
+    smaker run -e $endpoint --quiet -F
 done
 set +x
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='smaker',
-    version='0.0.3',
+    version='0.0.4',
     author='Max Hoffman',
     author_email='max@factual.com',
     description='Generalize snakemake workflows',

--- a/smaker/__init__.py
+++ b/smaker/__init__.py
@@ -1,0 +1,3 @@
+from smaker.path_gen import path_gen, config_to_targets, verify_config
+from smaker.utils import scrape_error_logs, scrape_final_targets
+from smaker.runner import SnakeRunner

--- a/smaker/cli.py
+++ b/smaker/cli.py
@@ -36,10 +36,11 @@ def run_on_the_fly(snakefile, configfile, extra_modules, extra_sources, workflow
 @click.option('--reason', is_flag=True, default=False)
 @click.option('--summary', is_flag=True, default=False)
 @click.option('--print-shell', is_flag=True, default=False)
+@click.option('--forceall', '-F', is_flag=True, default=False)
 @click.option('--unlock/--no-unlock', is_flag=True, default=False)
 @click.pass_context
 def main(context, cmd, endpoint, construct, module, source, snakefile, configfile, dryrun, quiet,
-         cores, rulegraph, reason, summary, print_shell, unlock):
+         cores, rulegraph, reason, summary, print_shell, forceall, unlock):
     """Smaker workflow tool
 
     The `run` command is used to execute pre-defined endpoints in a
@@ -97,7 +98,7 @@ def main(context, cmd, endpoint, construct, module, source, snakefile, configfil
 
     runners = [ getattr(cmodule, val) for val in dir(cmodule) if isinstance(getattr(cmodule, val), SnakeRunner) ]
     api_opts = { 'cores': cores, 'quiet': quiet, 'dryrun': dryrun , 'unlock': unlock, 'printrulegraph': rulegraph, 'printreason': reason, 'summary':
-                summary, 'printshellcmds': print_shell }
+                summary, 'printshellcmds': print_shell, 'forceall': forceall }
 
     if cmd == 'list': list_endpoints(runners)
     elif cmd == 'run': run_endpoint(endpoint, runners, api_opts)

--- a/smaker/path_gen.py
+++ b/smaker/path_gen.py
@@ -31,8 +31,6 @@ def path_gen(targets, output_path, parameters={}, sources=[]):
         template = os.path.join('{source}', template)
     else:
         full_paths = [os.path.join(output_path, p, t) for t in targets for p in partials]
-        #print('Source must be defined. Path-collapsing intentionally not supported at this time')
-        #raise
 
     full_paths = [p[:-1] if p[-1] == '/' else p for p in full_paths]
 

--- a/smaker/path_gen.py
+++ b/smaker/path_gen.py
@@ -30,9 +30,11 @@ def path_gen(targets, output_path, parameters={}, sources=[]):
         full_paths = [os.path.join(output_path, s, p, t) for t in targets for p in partials for s in sources]
         template = os.path.join('{source}', template)
     else:
-        # full_paths = [os.path.join(output_path, p, t) for t in targets for p in partials]
-        print('Source must be defined. Path-collapsing intentionally not supported at this time')
-        raise
+        full_paths = [os.path.join(output_path, p, t) for t in targets for p in partials]
+        #print('Source must be defined. Path-collapsing intentionally not supported at this time')
+        #raise
+
+    full_paths = [p[:-1] if p[-1] == '/' else p for p in full_paths]
 
     return full_paths, os.path.normpath(template)
 

--- a/smaker/runner.py
+++ b/smaker/runner.py
@@ -3,7 +3,7 @@ import functools
 import json
 import os
 import snakemake
-from smaker import path_gen
+import smaker
 from tqdm import tqdm
 import copy
 
@@ -70,7 +70,7 @@ class SnakeRunner:
         for co in config_overrides:
             base_config = copy.deepcopy(self.default_config)
             workflow_config = self._merge_configs(base_config, co)
-            workflow_config['final_paths'], workflow_config['run_wildcards'] = path_gen.config_to_targets([''], workflow_config)
+            workflow_config['final_paths'], workflow_config['run_wildcards'] = smaker.config_to_targets([''], workflow_config)
             subworkflow_configs += [workflow_config]
 
         if not api_opts.get('quiet', False):


### PR DESCRIPTION
+ Change import style so that everything's in the `smaker` namespace.
+ Add a force option, so that I can `-nF` to see the full rule list even if a job is completed.
+ Removes the forced source nesting
+ Fixes a bug where trailing slashes in folder paths were caught as a wildcard param if `source==None`