### PR TITLE
Makes it easier to run generic snakefiles

### DIFF
--- a/examples/hello_world/config.json
+++ b/examples/hello_world/config.json
@@ -5,6 +5,6 @@
     "modules": {"hello": "hello_world/Snakefile.hello"},
     "sources": ["hello-world"],
     "params": {
-		"say_hello": false
+        "say_hello": false
     }
 }

--- a/scripts/test_example_endpoints.sh
+++ b/scripts/test_example_endpoints.sh
@@ -18,7 +18,7 @@ smaker fly \
     --output-path=$OUTPUT_PATH \
     -F \
     -v |\
-    grep "$OUTPUT_PATH/$SOURCE"
+    #grep "$OUTPUT_PATH/$SOURCE"
 
 smaker fly \
     -c simple/config.json \
@@ -27,7 +27,7 @@ smaker fly \
     --output-path $OUTPUT_PATH \
     -F \
     -v |\
-    grep "$OUTPUT_PATH/default"
+    #grep "$OUTPUT_PATH/default"
 
 smaker fly \
     -c simple/config.json \

--- a/scripts/test_example_endpoints.sh
+++ b/scripts/test_example_endpoints.sh
@@ -17,8 +17,7 @@ smaker fly \
     --source=$SOURCE \
     --output-path=$OUTPUT_PATH \
     -F \
-    -v |\
-    #grep "$OUTPUT_PATH/$SOURCE"
+    -v
 
 smaker fly \
     -c simple/config.json \
@@ -26,8 +25,7 @@ smaker fly \
     --source $SOURCE \
     --output-path $OUTPUT_PATH \
     -F \
-    -v |\
-    #grep "$OUTPUT_PATH/default"
+    -v
 
 smaker fly \
     -c simple/config.json \

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='smaker',
-    version='0.0.5',
+    version='0.0.6',
     author='Max Hoffman',
     author_email='max@factual.com',
     description='Generalize snakemake workflows',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'numpy>=1.14.2',
         'pandas>=0.24.2',
         'tqdm>=4.32.2',
-        'pyarrow>=0.14.1'
+        'pyarrow>=0.14.1',
+        'omegaconf>=1.3.0'
     ],
     entry_points={
         'console_scripts': ['smaker=smaker.cli:main']

--- a/smaker/cli.py
+++ b/smaker/cli.py
@@ -3,8 +3,8 @@ from importlib.util import spec_from_loader, module_from_spec
 from importlib.machinery import SourceFileLoader
 import json
 import os
-import sys
 from smaker.runner import SnakeRunner
+import sys
 
 def list_endpoints(runners):
     return [ print(e) for r in runners for e in r.endpoints ]

--- a/smaker/cli.py
+++ b/smaker/cli.py
@@ -18,7 +18,7 @@ def run_endpoint(endpoint, runners, api_opts):
 
 def run_on_the_fly(snakefile, configfile, extra_modules, extra_sources, workflow_opts, api_opts):
     workflow_opts['modules'] = { os.path.dirname(os.path.normpath(mod)): mod for mod in extra_modules if os.path.isfile(mod) }
-    workflow_opts['sources'] = extra_sources
+    workflow_opts['sources'] = list(extra_sources)
     SnakeRunner.run_undefined_endpoint(configfile, snakefile, workflow_opts, api_opts)
 
 @click.command(name='smaker', context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))

--- a/smaker/path_gen.py
+++ b/smaker/path_gen.py
@@ -2,7 +2,9 @@ import numpy as np
 import os
 
 def config_to_targets(targets, config):
-    return path_gen(targets, config['output_path'], parameters=config.get('params', {}),
+    return path_gen(targets,
+                    config['output_path'],
+                    parameters=config.get('params', {}),
                     sources=config.get('sources', []))
 
 def path_gen(targets, output_path, parameters={}, sources=[]):

--- a/smaker/runner.py
+++ b/smaker/runner.py
@@ -1,13 +1,13 @@
 from backports import tempfile
+import copy
 import functools
 import json
+import omegaconf
+from omegaconf import OmegaConf
 import os
 import snakemake
 import smaker
 from tqdm import tqdm
-import copy
-from omegaconf import OmegaConf
-import omegaconf
 
 class TqdmExtraFormat(tqdm):
     "Style change copied from tqdm documentation"

--- a/smaker/runner.py
+++ b/smaker/runner.py
@@ -6,9 +6,8 @@ import snakemake
 import smaker
 from tqdm import tqdm
 import copy
-
-def pretty_dump(blob):
-    return json.dumps(blob, indent=4, sort_keys=True)
+from omegaconf import OmegaConf
+import omegaconf
 
 class TqdmExtraFormat(tqdm):
     "Style change copied from tqdm documentation"
@@ -39,23 +38,7 @@ class SnakeRunner:
         self.cores = cores
         self.configfile = default_config
         self.default_snakefile = os.path.abspath(default_snakefile)
-        with open(default_config, 'r') as cf:
-            self.default_config = json.load(cf)
-
-    def _merge_configs(self, base, overrides, nested_fields=['params', 'modules', 'sources']):
-        for field in nested_fields:
-            if overrides.get(field, None) != None:
-                collection = overrides[field]
-                if isinstance(collection, dict):
-                    if base.get(field, None) == None: base[field] == {}
-                    base[field].update(overrides[field])
-                    del overrides[field]
-                elif isinstance(collection, (tuple, list, set)):
-                    if base.get(field, None) == None: base[field] == []
-                    base[field] += list(collection)
-                    del overrides[field]
-        base.update(overrides)
-        return base
+        self.default_config = OmegaConf.load(default_config)
 
     def run(self, endpoint, api_opts):
         dryrun = api_opts.pop('dryrun', True)
@@ -66,21 +49,15 @@ class SnakeRunner:
         if isinstance(config_overrides, dict): config_overrides = [config_overrides]
         assert len(config_overrides) > 0, "No configs found: %s" % endpoint
 
-        subworkflow_configs = []
-        for co in config_overrides:
-            base_config = copy.deepcopy(self.default_config)
-            workflow_config = self._merge_configs(base_config, co)
-            workflow_config['final_paths'], workflow_config['run_wildcards'] = smaker.config_to_targets([''], workflow_config)
-            subworkflow_configs += [workflow_config]
-
-        if not api_opts.get('quiet', False):
-            print('API options set:\n%s' % pretty_dump(api_opts))
-            print('Workflow opts:\n%s' % pretty_dump(subworkflow_configs))
+        config_overrides = [c if isinstance(c, omegaconf.dictconfig.DictConfig) else OmegaConf.create(c) for c in config_overrides]
+        subworkflow_configs = [OmegaConf.merge(self.default_config, c) for c in config_overrides]
 
         with tempfile.TemporaryDirectory() as temp_dir:
             config_paths = [os.path.abspath(os.path.join(temp_dir, 'config%s.json' % idx)) for idx in range(len(subworkflow_configs))]
             for config, path in zip(subworkflow_configs, config_paths):
-                with open(path, 'w+') as f: json.dump(config, f)
+                if config.get('params') != None:
+                    config['final_paths'], config['run_wildcards'] = smaker.config_to_targets([''], config)
+                config.save(path)
 
             pbar = TqdmExtraFormat(config_paths, ascii=True , bar_format="{total_time}: {percentage:.0f}%|{bar}{r_bar}")
             for i, cpath in enumerate(pbar):
@@ -94,7 +71,6 @@ class SnakeRunner:
 
     @classmethod
     def run_undefined_endpoint(cls, configfile, snakefile, workflow_opts={}, api_opts={'cores': 2}):
-        print('Running with dynamic workflow opts:\n%s' % pretty_dump(workflow_opts))
         sn = cls(configfile, snakefile)
         sn.add_endpoint('_undefined', workflow_opts)
         sn.run('_undefined', api_opts)


### PR DESCRIPTION
I can run generic snakefiles now. This sort of clashes with the new `configfiles` option in the new snakemake, but that requires Python>=3.6.0.

Ex:
```Python
from smaker import SnakeRunner
from omegaconf import OmegaConf

default_sn = SnakeRunner(default_snakefile='Snakefile', default_config='conf/default.yaml')
theater_sn = SnakeRunner(default_snakefile='Snakefile', default_config='conf/theater1.yaml')
stadium_sn = SnakeRunner(default_snakefile='Snakefile', default_config='conf/stadium1.yaml')

source_confs = [OmegaConf.load(c) for c in ['conf/stadium1.yaml', 'conf/theater1.yaml', 'conf/bk.yaml']]

numerator_models = [
        ('4.5.0', ''),
        ('train=dca_test=dca_shard=0', ''),
        ('train=numerator_test=dca_shard=0', ''),
        ('train=numerator-dca_test=dca_shard=0', ''),
]

numerator_model_confs = [OmegaConf.create({
        'opts': {
                'pa_model_tag': m,
                'pa_model_path': p
        }
}) for m, p in numerator_models]

numerator_ab1 = [OmegaConf.merge(s, m) for s in source_confs for m in numerator_model_confs]
default_sn.add_endpoint('numerator_ab1', numerator_ab1)
```